### PR TITLE
Add reference frame selection for PET

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -38,6 +38,11 @@ Command-Line Arguments
    :nodefault:
    :nodefaultconst:
 
+The ``--reference-frame`` option selects a specific frame of the PET
+time series to generate the motion-correction reference. Use ``--reference-frame
+<index>`` to pick a particular frame or ``--reference-frame average`` (default)
+to compute a robust average across frames.
+
 
 The command-line interface of the docker wrapper
 ------------------------------------------------

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -145,6 +145,16 @@ def _build_parser(**kwargs):
             raise parser.error(f'Slice time reference must be in range 0-1. Received {value}.')
         return value
 
+    def _reference_frame(value, parser):
+        if value == 'average':
+            return 'average'
+        try:
+            return int(value)
+        except ValueError:
+            raise parser.error(
+                "Reference frame must be an integer index or 'average'."
+            ) from None
+
     verstr = f'PETPrep v{config.environment.version}'
     currentv = Version(config.environment.version)
     is_release = not any((currentv.is_devrelease, currentv.is_prerelease, currentv.is_postrelease))
@@ -158,6 +168,7 @@ def _build_parser(**kwargs):
     IsFile = partial(_is_file, parser=parser)
     PositiveInt = partial(_min_one, parser=parser)
     BIDSFilter = partial(_bids_filter, parser=parser)
+    ReferenceFrame = partial(_reference_frame, parser=parser)
 
     # Arguments as specified by BIDS-Apps
     # required, positional arguments
@@ -383,6 +394,17 @@ https://petprep.readthedocs.io/en/%s/spaces.html"""
         default=None,
         type=int,
         help='Number of nonsteady-state volumes. Overrides automatic detection.',
+    )
+    g_conf.add_argument(
+        '--reference-frame',
+        action='store',
+        dest='reference_frame',
+        type=ReferenceFrame,
+        default='average',
+        help=(
+            "Reference frame index (0-based) for PET preprocessing. "
+            "Use 'average' to compute the standard averaged reference."
+        ),
     )
     g_conf.add_argument(
         '--random-seed',

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -595,6 +595,11 @@ class workflow(_Config):
     """Keeps the :py:class:`~niworkflows.utils.spaces.SpatialReferences`
     instance keeping standard and nonstandard spaces."""
 
+    reference_frame: int | str | None = None
+    """Selected frame index for PET reference generation.
+
+    ``None`` or ``'average'`` retains the current averaging behavior."""
+
 
 class loggers:
     """Keep loggers easily accessible (see :py:func:`init`)."""

--- a/fmriprep/workflows/pet/fit.py
+++ b/fmriprep/workflows/pet/fit.py
@@ -253,6 +253,7 @@ def init_pet_fit_wf(
         petref_wf = init_raw_petref_wf(
             name='petref_wf',
             pet_file=pet_file,
+            reference_frame=config.workflow.reference_frame,
         )
         petref_wf.inputs.inputnode.dummy_scans = config.workflow.dummy_scans
 

--- a/fmriprep/workflows/pet/reference.py
+++ b/fmriprep/workflows/pet/reference.py
@@ -21,6 +21,7 @@
 #     https://www.nipreps.org/community/licensing/
 #
 from nipype.interfaces import utility as niu
+from nipype.interfaces import fsl
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.header import ValidateImage
@@ -31,6 +32,8 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 
 def init_raw_petref_wf(
     pet_file=None,
+    *,
+    reference_frame: int | str | None = None,
     name='raw_petref_wf',
 ):
     """
@@ -54,6 +57,9 @@ def init_raw_petref_wf(
     ----------
     pet_file : :obj:`str`
         PET series NIfTI file
+    reference_frame : :obj:`int` or ``"average"`` or ``None``
+        Select a specific volume to use as reference. ``None`` or ``"average"``
+        computes a robust average across frames.
     name : :obj:`str`
         Name of workflow (default: ``pet_reference_wf``)
 
@@ -109,24 +115,45 @@ using a custom methodology of *fMRIPrep*, for use in head motion correction.
     validation_and_dummies_wf = init_validation_and_dummies_wf()
 
     gen_avg = pe.Node(RobustAverage(), name='gen_avg', mem_gb=1)
+    extract_roi = pe.Node(
+        fsl.ExtractROI(t_size=1),
+        name='extract_frame',
+        mem_gb=DEFAULT_MEMORY_MIN_GB,
+    )
 
-    workflow.connect([
-        (inputnode, validation_and_dummies_wf, [
-            ('pet_file', 'inputnode.pet_file'),
-            ('dummy_scans', 'inputnode.dummy_scans'),
-        ]),
-        (validation_and_dummies_wf, gen_avg, [
-            ('outputnode.pet_file', 'in_file'),
-            ('outputnode.t_mask', 't_mask'),
-        ]),
-        (validation_and_dummies_wf, outputnode, [
-            ('outputnode.pet_file', 'pet_file'),
-            ('outputnode.skip_vols', 'skip_vols'),
-            ('outputnode.algo_dummy_scans', 'algo_dummy_scans'),
-            ('outputnode.validation_report', 'validation_report'),
-        ]),
-        (gen_avg, outputnode, [('out_file', 'petref')]),
-    ])  # fmt:skip
+    workflow.connect(
+        [
+            (inputnode, validation_and_dummies_wf, [
+                ('pet_file', 'inputnode.pet_file'),
+                ('dummy_scans', 'inputnode.dummy_scans'),
+            ]),
+            (validation_and_dummies_wf, outputnode, [
+                ('outputnode.pet_file', 'pet_file'),
+                ('outputnode.skip_vols', 'skip_vols'),
+                ('outputnode.algo_dummy_scans', 'algo_dummy_scans'),
+                ('outputnode.validation_report', 'validation_report'),
+            ]),
+        ]
+    )  # fmt:skip
+
+    if reference_frame in (None, 'average'):
+        workflow.connect(
+            [
+                (validation_and_dummies_wf, gen_avg, [
+                    ('outputnode.pet_file', 'in_file'),
+                    ('outputnode.t_mask', 't_mask'),
+                ]),
+                (gen_avg, outputnode, [('out_file', 'petref')]),
+            ]
+        )  # fmt:skip
+    else:
+        extract_roi.inputs.t_min = int(reference_frame)
+        workflow.connect(
+            [
+                (validation_and_dummies_wf, extract_roi, [('outputnode.pet_file', 'in_file')]),
+                (extract_roi, outputnode, [('roi_file', 'petref')]),
+            ]
+        )  # fmt:skip
 
     return workflow
 

--- a/fmriprep/workflows/pet/tests/test_reference.py
+++ b/fmriprep/workflows/pet/tests/test_reference.py
@@ -1,0 +1,28 @@
+import nibabel as nb
+import numpy as np
+
+from ..reference import init_raw_petref_wf
+
+
+def test_reference_frame_select(tmp_path):
+    img = nb.Nifti1Image(np.zeros((5, 5, 5, 4)), np.eye(4))
+    pet_file = tmp_path / "pet.nii.gz"
+    img.to_filename(pet_file)
+
+    wf = init_raw_petref_wf(pet_file=str(pet_file), reference_frame=2)
+    node_names = [n.name for n in wf._get_all_nodes()]
+    assert "extract_frame" in node_names
+    assert "gen_avg" not in node_names
+    node = wf.get_node("extract_frame")
+    assert node.interface.inputs.t_min == 2
+
+
+def test_reference_frame_average(tmp_path):
+    img = nb.Nifti1Image(np.zeros((5, 5, 5, 4)), np.eye(4))
+    pet_file = tmp_path / "pet.nii.gz"
+    img.to_filename(pet_file)
+
+    wf = init_raw_petref_wf(pet_file=str(pet_file), reference_frame="average")
+    node_names = [n.name for n in wf._get_all_nodes()]
+    assert "gen_avg" in node_names
+


### PR DESCRIPTION
## Summary
- add `reference_frame` workflow configuration
- expose `--reference-frame` CLI option
- use selected frame in PET reference workflow
- propagate frame selection to PET fit workflow
- document CLI option
- test custom reference frame logic

## Testing
- `pytest -c /dev/null fmriprep/workflows/pet/tests/test_reference.py -q`