### PR TITLE
Rename env and update PETPrep references

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,11 +8,11 @@ Note that derivatives from previous versions will be accepted,
 so it should not be necessary to recompute derivatives from previous versions.
 The recommended command line is::
 
-    fmriprep BIDS_DIR OUT_DIR participant --derivatives fmriprep=PRECOMP_DIR
+    petprep BIDS_DIR OUT_DIR participant --derivatives petprep=PRECOMP_DIR
 
 Note that multiple derivatives can be specified, for example::
 
-    fmriprep BIDS_DIR OUT_DIR participant \
+    petprep BIDS_DIR OUT_DIR participant \
       anat=PRECOMPUTED_ANATOMICAL_DIR \
       func=PRECOMPUTED_FUNCTIONAL_DIR
 

--- a/docs/_static/sbatch.slurm
+++ b/docs/_static/sbatch.slurm
@@ -19,9 +19,9 @@ LOCAL_FREESURFER_DIR="$STUDY/data/derivatives/freesurfer-6.0.1"
 
 # Prepare some writeable bind-mount points.
 TEMPLATEFLOW_HOST_HOME=$HOME/.cache/templateflow
-FMRIPREP_HOST_CACHE=$HOME/.cache/petprep
+PETPREP_HOST_CACHE=$HOME/.cache/petprep
 mkdir -p ${TEMPLATEFLOW_HOST_HOME}
-mkdir -p ${FMRIPREP_HOST_CACHE}
+mkdir -p ${PETPREP_HOST_CACHE}
 
 # Prepare derivatives folder
 mkdir -p ${BIDS_DIR}/${DERIVS_DIR}

--- a/env.yml
+++ b/env.yml
@@ -1,4 +1,4 @@
-name: fmriprep
+name: petprep
 channels:
   - https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/
   - conda-forge

--- a/scripts/fetch_templates.py
+++ b/scripts/fetch_templates.py
@@ -3,7 +3,7 @@
 Standalone script to facilitate caching of required TemplateFlow templates.
 
 To download and view how to use this script, run the following commands inside a terminal:
-1. wget https://raw.githubusercontent.com/nipreps/fmriprep/master/scripts/fetch_templates.py
+1. wget https://raw.githubusercontent.com/nipreps/petprep/master/scripts/fetch_templates.py
 2. python fetch_templates.py -h
 """
 
@@ -22,7 +22,7 @@ def fetch_MNI2009():
     tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-01_desc-brain_mask.nii.gz
     tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-02_desc-brain_mask.nii.gz
     tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-01_desc-carpet_dseg.nii.gz
-    tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-02_desc-fMRIPrep_boldref.nii.gz
+    tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-02_desc-PETPrep_boldref.nii.gz
     tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-01_label-brain_probseg.nii.gz
     """
     template = 'MNI152NLin2009cAsym'
@@ -30,7 +30,7 @@ def fetch_MNI2009():
     tf.get(template, resolution=(1, 2), desc=None, suffix=['T1w', 'T2w'])
     tf.get(template, resolution=(1, 2), desc='brain', suffix='mask')
     tf.get(template, resolution=1, atlas=None, desc='carpet', suffix='dseg')
-    tf.get(template, resolution=2, desc='fMRIPrep', suffix='boldref')
+    tf.get(template, resolution=2, desc='PETPrep', suffix='boldref')
     tf.get(template, resolution=1, label='brain', suffix='probseg')
 
 
@@ -119,7 +119,7 @@ def fetch_all():
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description='Helper script for pre-caching required templates to run fMRIPrep',
+        description='Helper script for pre-caching required templates to run PETPrep',
     )
     parser.add_argument(
         '--tf-dir',


### PR DESCRIPTION
## Summary
- update env.yml name to petprep
- adjust CHANGES instructions for PETPrep
- update fetch_templates.py references and description
- use PETPrep variable names in docs sbatch script

## Testing
- `pytest -k 'nomatch'` *(fails: unrecognized arguments)*