### PR TITLE
Update Docker configs for PETPrep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN micromamba create -y -f /tmp/env.yml && \
 
 # UV_USE_IO_URING for apparent race-condition (https://github.com/nodejs/node/issues/48444)
 # Check if this is still necessary when updating the base image.
-ENV PATH="/opt/conda/envs/fmriprep/bin:$PATH" \
+ENV PATH="/opt/conda/envs/petprep/bin:$PATH" \
     UV_USE_IO_URING=0
 RUN npm install -g svgo@^3.2.0 bids-validator@1.14.10 && \
     rm -r ~/.npm
@@ -195,14 +195,14 @@ ENV HOME="/home/fmriprep" \
     LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
 
 COPY --from=micromamba /bin/micromamba /bin/micromamba
-COPY --from=micromamba /opt/conda/envs/fmriprep /opt/conda/envs/fmriprep
+COPY --from=micromamba /opt/conda/envs/fmriprep /opt/conda/envs/petprep
 
 ENV MAMBA_ROOT_PREFIX="/opt/conda"
 RUN micromamba shell init -s bash && \
-    echo "micromamba activate fmriprep" >> $HOME/.bashrc
-ENV PATH="/opt/conda/envs/fmriprep/bin:$PATH" \
-    CPATH="/opt/conda/envs/fmriprep/include:$CPATH" \
-    LD_LIBRARY_PATH="/opt/conda/envs/fmriprep/lib:$LD_LIBRARY_PATH"
+    echo "micromamba activate petprep" >> $HOME/.bashrc
+ENV PATH="/opt/conda/envs/petprep/bin:$PATH" \
+    CPATH="/opt/conda/envs/petprep/include:$CPATH" \
+    LD_LIBRARY_PATH="/opt/conda/envs/petprep/lib:$LD_LIBRARY_PATH"
 
 # Precaching atlases
 COPY scripts/fetch_templates.py fetch_templates.py
@@ -215,7 +215,7 @@ RUN python fetch_templates.py && \
 ENV LANG="C.UTF-8" \
     LC_ALL="C.UTF-8" \
     PYTHONNOUSERSITE=1 \
-    FSLDIR="/opt/conda/envs/fmriprep" \
+    FSLDIR="/opt/conda/envs/petprep" \
     FSLOUTPUTTYPE="NIFTI_GZ" \
     FSLMULTIFILEQUIT="TRUE" \
     FSLLOCKDIR="" \
@@ -245,16 +245,16 @@ ENV IS_DOCKER_8395080871=1
 
 RUN ldconfig
 WORKDIR /tmp
-ENTRYPOINT ["/opt/conda/envs/fmriprep/bin/fmriprep"]
+ENTRYPOINT ["/opt/conda/envs/petprep/bin/petprep"]
 
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
 LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.name="fMRIPrep" \
-      org.label-schema.description="fMRIPrep - robust fMRI preprocessing tool" \
-      org.label-schema.url="https://fmriprep.org" \
+      org.label-schema.name="PETPrep" \
+      org.label-schema.description="PETPrep - robust PET preprocessing tool" \
+      org.label-schema.url="https://petprep.org" \
       org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url="https://github.com/nipreps/fmriprep" \
+      org.label-schema.vcs-url="https://github.com/PETPrep/petprep" \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"

--- a/Dockerfile_devel
+++ b/Dockerfile_devel
@@ -78,7 +78,7 @@ RUN /src/codeserver/code-server --install-extension eamodio.gitlens &&\
     /src/codeserver/code-server --install-extension ms-python.python
 
 
-ENTRYPOINT ["/src/codeserver/code-server", "--auth", "none", "/src/fmriprep"]
+ENTRYPOINT ["/opt/conda/envs/petprep/bin/petprep"]
 
 # usage example (assuming in local fmriprep directory):
 #

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: help docker-build
 .DEFAULT: help
 
-tag="fmriprep"
+tag="petprep"
 
 help:
 	@echo "Premade recipes"
 	@echo
 	@echo "make docker-build [tag=TAG]"
-	@echo "\tBuilds a docker image from source. Defaults to 'fmriprep' tag."
+@echo "\tBuilds a docker image from source. Defaults to 'petprep' tag."
 
 
 docker-build:


### PR DESCRIPTION
## Summary
- use PETPrep environment in Dockerfiles
- set PETPrep as entrypoint
- update image labels
- default Docker tag is now `petprep`

## Testing
- `pytest -q` *(fails: unrecognized arguments)*