### PR TITLE
Switch references from fmriprep to petprep

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -630,7 +630,7 @@ https://petprep.readthedocs.io/en/%s/spaces.html"""
         default=False,
         help='Opt-out of sending tracking information of this run to '
         'the PETPREP developers. This information helps to '
-        'improve FMRIPREP and provides an indicator of real '
+        'improve PETPrep and provides an indicator of real '
         'world usage crucial for obtaining funding.',
     )
     g_other.add_argument(

--- a/petprep/cli/run.py
+++ b/petprep/cli/run.py
@@ -54,7 +54,7 @@ def main():
         tracker.start()
 
     if 'pdb' in config.execution.debug:
-        from fmriprep.utils.debug import setup_exceptionhook
+        from petprep.utils.debug import setup_exceptionhook
 
         setup_exceptionhook()
         config.nipype.plugin = 'Linear'
@@ -205,7 +205,7 @@ def main():
             config.loggers.workflow.log(25, f'Saving logs at: {config.execution.log_dir}')
             config.loggers.workflow.log(25, f'Carbon emissions: {emissions} kg')
 
-        from fmriprep.reports.core import generate_reports
+        from petprep.reports.core import generate_reports
 
         # Generate reports phase
         session_list = (

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -117,7 +117,7 @@ def test_get_parser_update(monkeypatch, capsys, current, latest):
     msg = f"""\
 You are using fMRIPrep-{current}, and a newer version of fMRIPrep is available: {latest}.
 Please check out our documentation about how and when to upgrade:
-https://fmriprep.readthedocs.io/en/latest/faq.html#upgrading"""
+https://petprep.readthedocs.io/en/latest/faq.html#upgrading"""
 
     assert (msg in captured) is expectation
 

--- a/petprep/cli/workflow.py
+++ b/petprep/cli/workflow.py
@@ -38,8 +38,8 @@ def build_workflow(config_file, retval):
     from niworkflows.utils.bids import collect_participants
     from niworkflows.utils.misc import check_valid_fs_license
 
-    from fmriprep.reports.core import generate_reports
-    from fmriprep.utils.bids import check_pipeline_version
+    from petprep.reports.core import generate_reports
+    from petprep.utils.bids import check_pipeline_version
 
     from .. import config, data
     from ..utils.misc import check_deps

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -37,7 +37,7 @@ the settings to hard disk in *ToML* format, which looks like:
    :caption: **Example file representation of PETPrep settings**.
 
 This config file is used to pass the settings across processes,
-using the :py:func:`~fmriprep.config.load` function.
+using the :py:func:`~petprep.config.load` function.
 
 Configuration sections
 ----------------------

--- a/petprep/interfaces/reports.py
+++ b/petprep/interfaces/reports.py
@@ -211,8 +211,8 @@ class FunctionalSummary(SummaryInterface):
 
 
 class AboutSummaryInputSpec(BaseInterfaceInputSpec):
-    version = Str(desc='FMRIPREP version')
-    command = Str(desc='FMRIPREP command')
+    version = Str(desc='PETPrep version')
+    command = Str(desc='PETPrep command')
     # Date not included - update timestamp only if version or command changes
 
 

--- a/petprep/interfaces/tests/test_bids.py
+++ b/petprep/interfaces/tests/test_bids.py
@@ -1,9 +1,9 @@
-"""Tests for fmriprep.interfaces.bids."""
+"""Tests for petprep.interfaces.bids."""
 
 
 def test_BIDSURI():
     """Test the BIDSURI interface."""
-    from fmriprep.interfaces.bids import BIDSURI
+    from petprep.interfaces.bids import BIDSURI
 
     dataset_links = {
         'raw': '/data',

--- a/petprep/interfaces/tests/test_confounds.py
+++ b/petprep/interfaces/tests/test_confounds.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from nipype.pipeline import engine as pe
 
-from fmriprep.interfaces import confounds
+from petprep.interfaces import confounds
 
 
 def test_RenameACompCor(tmp_path, data_dir):

--- a/petprep/interfaces/tests/test_maths.py
+++ b/petprep/interfaces/tests/test_maths.py
@@ -2,7 +2,7 @@ import nibabel as nb
 import numpy as np
 from nipype.pipeline import engine as pe
 
-from fmriprep.interfaces.maths import Clip
+from petprep.interfaces.maths import Clip
 
 
 def test_Clip(tmp_path):

--- a/petprep/interfaces/workbench.py
+++ b/petprep/interfaces/workbench.py
@@ -569,7 +569,7 @@ class VolumeToSurfaceMapping(WBCommand, OpenMPCommandMixin):
         intended to be larger than where the cylinder cutoff should have been.
 
     Examples:
-    >>> from fmriprep.interfaces.workbench import VolumeToSurfaceMapping
+    >>> from petprep.interfaces.workbench import VolumeToSurfaceMapping
     >>> vol2surf = VolumeToSurfaceMapping()
     >>> vol2surf.inputs.volume_file = 'bold.nii.gz'
     >>> vol2surf.inputs.surface_file = 'lh.midthickness.surf.gii'
@@ -659,7 +659,7 @@ class MetricMask(WBCommand):
 
     Examples
 
-    >>> from fmriprep.interfaces.workbench import MetricMask
+    >>> from petprep.interfaces.workbench import MetricMask
     >>> metric_mask = MetricMask()
     >>> metric_mask.inputs.in_file = 'lh.bold.func.gii'
     >>> metric_mask.inputs.mask = 'lh.roi.shape.gii'
@@ -725,7 +725,7 @@ class MetricFillHoles(WBCommand):
 
     Examples
 
-    >>> from fmriprep.interfaces.workbench import MetricFillHoles
+    >>> from petprep.interfaces.workbench import MetricFillHoles
     >>> fill_holes = MetricFillHoles()
     >>> fill_holes.inputs.surface_file = 'lh.midthickness.surf.gii'
     >>> fill_holes.inputs.metric_file = 'lh.roi.shape.gii'
@@ -792,7 +792,7 @@ class MetricRemoveIslands(WBCommand):
 
     Examples
 
-    >>> from fmriprep.interfaces.workbench import MetricRemoveIslands
+    >>> from petprep.interfaces.workbench import MetricRemoveIslands
     >>> remove_islands = MetricRemoveIslands()
     >>> remove_islands.inputs.surface_file = 'lh.midthickness.surf.gii'
     >>> remove_islands.inputs.metric_file = 'lh.roi.shape.gii'

--- a/petprep/reports/tests/test_reports.py
+++ b/petprep/reports/tests/test_reports.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from bids.layout import BIDSLayout
 
-from fmriprep.reports.core import generate_reports
+from petprep.reports.core import generate_reports
 
 from ... import config, data
 

--- a/petprep/utils/bids.py
+++ b/petprep/utils/bids.py
@@ -112,7 +112,7 @@ def write_bidsignore(deriv_dir):
 def write_derivative_description(bids_dir, deriv_dir, dataset_links=None):
     from .. import __version__
 
-    DOWNLOAD_URL = f'https://github.com/nipreps/fmriprep/archive/{__version__}.tar.gz'
+    DOWNLOAD_URL = f'https://github.com/nipreps/petprep/archive/{__version__}.tar.gz'
 
     bids_dir = Path(bids_dir)
     deriv_dir = Path(deriv_dir)
@@ -133,15 +133,15 @@ def write_derivative_description(bids_dir, deriv_dir, dataset_links=None):
     }
 
     # Keys that can only be set by environment
-    if 'FMRIPREP_DOCKER_TAG' in os.environ:
+    if 'PETPREP_DOCKER_TAG' in os.environ:
         desc['GeneratedBy'][0]['Container'] = {
             'Type': 'docker',
-            'Tag': f'nipreps/fmriprep:{os.environ["FMRIPREP_DOCKER_TAG"]}',
+            'Tag': f'nipreps/petprep:{os.environ["PETPREP_DOCKER_TAG"]}',
         }
-    if 'FMRIPREP_SINGULARITY_URL' in os.environ:
+    if 'PETPREP_SINGULARITY_URL' in os.environ:
         desc['GeneratedBy'][0]['Container'] = {
             'Type': 'singularity',
-            'URI': os.getenv('FMRIPREP_SINGULARITY_URL'),
+            'URI': os.getenv('PETPREP_SINGULARITY_URL'),
         }
 
     # Keys deriving from source dataset

--- a/petprep/utils/tests/test_derivative_cache.py
+++ b/petprep/utils/tests/test_derivative_cache.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from fmriprep.utils import bids
+from petprep.utils import bids
 
 
 @pytest.mark.parametrize('desc', ['hmc', 'coreg'])

--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -61,8 +61,8 @@ def init_petprep_wf():
             :graph2use: orig
             :simple_form: yes
 
-            from fmriprep.workflows.tests import mock_config
-            from fmriprep.workflows.base import init_petprep_wf
+            from petprep.workflows.tests import mock_config
+            from petprep.workflows.base import init_petprep_wf
             with mock_config():
                 wf = init_petprep_wf()
 
@@ -129,8 +129,8 @@ def init_single_subject_wf(subject_id: str):
             :graph2use: orig
             :simple_form: yes
 
-            from fmriprep.workflows.tests import mock_config
-            from fmriprep.workflows.base import init_single_subject_wf
+            from petprep.workflows.tests import mock_config
+            from petprep.workflows.base import init_single_subject_wf
             with mock_config():
                 wf = init_single_subject_wf('01')
 
@@ -166,7 +166,7 @@ def init_single_subject_wf(subject_id: str):
         init_resample_surfaces_wf,
     )
 
-    from fmriprep.workflows.pet.base import init_pet_wf
+    from petprep.workflows.pet.base import init_pet_wf
 
     workflow = Workflow(name=f'sub_{subject_id}_wf')
     workflow.__desc__ = f"""
@@ -184,7 +184,7 @@ Many internal operations of *fMRIPrep* use
 mostly within the PET processing workflow.
 For more details of the pipeline, see [the section corresponding
 to workflows in *fMRIPrep*'s documentation]\
-(https://fmriprep.readthedocs.io/en/latest/workflows.html \
+(https://petprep.readthedocs.io/en/latest/workflows.html \
 "FMRIPrep's documentation").
 
 
@@ -544,7 +544,7 @@ tasks and sessions), the following preprocessing was performed.
     for pet_series in pet_runs:
         pet_cache = {}
         if config.execution.derivatives:
-            from fmriprep.utils.bids import collect_derivatives, extract_entities
+            from petprep.utils.bids import collect_derivatives, extract_entities
 
             entities = extract_entities(pet_series)
 

--- a/petprep/workflows/pet/__init__.py
+++ b/petprep/workflows/pet/__init__.py
@@ -5,12 +5,12 @@
 Pre-processing PET workflows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automodule:: fmriprep.workflows.pet.base
-.. automodule:: fmriprep.workflows.pet.hmc
-.. automodule:: fmriprep.workflows.pet.stc
-.. automodule:: fmriprep.workflows.pet.registration
-.. automodule:: fmriprep.workflows.pet.resampling
-.. automodule:: fmriprep.workflows.pet.confounds
+.. automodule:: petprep.workflows.pet.base
+.. automodule:: petprep.workflows.pet.hmc
+.. automodule:: petprep.workflows.pet.stc
+.. automodule:: petprep.workflows.pet.registration
+.. automodule:: petprep.workflows.pet.resampling
+.. automodule:: petprep.workflows.pet.confounds
 
 
 """

--- a/petprep/workflows/pet/apply.py
+++ b/petprep/workflows/pet/apply.py
@@ -20,7 +20,7 @@ def init_pet_volumetric_resample_wf(
 
     .. workflow::
 
-        from fmriprep.workflows.pet.resampling import init_pet_volumetric_resample_wf
+        from petprep.workflows.pet.resampling import init_pet_volumetric_resample_wf
         wf = init_pet_volumetric_resample_wf(
             mem_gb={'resampled': 1},
         )

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -63,9 +63,9 @@ def init_pet_wf(
             :graph2use: orig
             :simple_form: yes
 
-            from fmriprep.workflows.tests import mock_config
+            from petprep.workflows.tests import mock_config
             from fmriprep import config
-            from fmriprep.workflows.pet.base import init_pet_wf
+            from petprep.workflows.pet.base import init_pet_wf
             with mock_config():
                 pet_file = config.execution.bids_dir / "sub-01" / "pet" \
                     / "sub-01_task-mixedgamblestask_run-01_pet.nii.gz"
@@ -134,16 +134,16 @@ def init_pet_wf(
     See Also
     --------
 
-    * :func:`~fmriprep.workflows.pet.fit.init_pet_fit_wf`
-    * :func:`~fmriprep.workflows.pet.fit.init_pet_native_wf`
-    * :func:`~fmriprep.workflows.pet.apply.init_pet_volumetric_resample_wf`
-    * :func:`~fmriprep.workflows.pet.outputs.init_ds_pet_native_wf`
-    * :func:`~fmriprep.workflows.pet.outputs.init_ds_volumes_wf`
-    * :func:`~fmriprep.workflows.pet.resampling.init_pet_surf_wf`
-    * :func:`~fmriprep.workflows.pet.resampling.init_pet_fsLR_resampling_wf`
-    * :func:`~fmriprep.workflows.pet.resampling.init_pet_grayords_wf`
-    * :func:`~fmriprep.workflows.pet.confounds.init_pet_confs_wf`
-    * :func:`~fmriprep.workflows.pet.confounds.init_carpetplot_wf`
+    * :func:`~petprep.workflows.pet.fit.init_pet_fit_wf`
+    * :func:`~petprep.workflows.pet.fit.init_pet_native_wf`
+    * :func:`~petprep.workflows.pet.apply.init_pet_volumetric_resample_wf`
+    * :func:`~petprep.workflows.pet.outputs.init_ds_pet_native_wf`
+    * :func:`~petprep.workflows.pet.outputs.init_ds_volumes_wf`
+    * :func:`~petprep.workflows.pet.resampling.init_pet_surf_wf`
+    * :func:`~petprep.workflows.pet.resampling.init_pet_fsLR_resampling_wf`
+    * :func:`~petprep.workflows.pet.resampling.init_pet_grayords_wf`
+    * :func:`~petprep.workflows.pet.confounds.init_pet_confs_wf`
+    * :func:`~petprep.workflows.pet.confounds.init_carpetplot_wf`
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow

--- a/petprep/workflows/pet/confounds.py
+++ b/petprep/workflows/pet/confounds.py
@@ -83,7 +83,7 @@ def init_pet_confs_wf(
             :graph2use: orig
             :simple_form: yes
 
-            from fmriprep.workflows.pet.confounds import init_pet_confs_wf
+            from petprep.workflows.pet.confounds import init_pet_confs_wf
             wf = init_pet_confs_wf(
                 mem_gb=1,
                 metadata={},

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -61,9 +61,9 @@ def init_pet_fit_wf(
             :graph2use: orig
             :simple_form: yes
 
-            from fmriprep.workflows.tests import mock_config
+            from petprep.workflows.tests import mock_config
             from fmriprep import config
-            from fmriprep.workflows.pet.fit import init_pet_fit_wf
+            from petprep.workflows.pet.fit import init_pet_fit_wf
             with mock_config():
                 pet_file = config.execution.bids_dir / "sub-01" / "func" \
                     / "sub-01_task-mixedgamblestask_run-01_pet.nii.gz"
@@ -112,17 +112,17 @@ def init_pet_fit_wf(
     See Also
     --------
 
-    * :py:func:`~fmriprep.workflows.pet.reference.init_raw_petref_wf`
-    * :py:func:`~fmriprep.workflows.pet.hmc.init_pet_hmc_wf`
-    * :py:func:`~fmriprep.workflows.pet.registration.init_pet_reg_wf`
-    * :py:func:`~fmriprep.workflows.pet.outputs.init_ds_petref_wf`
-    * :py:func:`~fmriprep.workflows.pet.outputs.init_ds_hmc_wf`
-    * :py:func:`~fmriprep.workflows.pet.outputs.init_ds_registration_wf`
+    * :py:func:`~petprep.workflows.pet.reference.init_raw_petref_wf`
+    * :py:func:`~petprep.workflows.pet.hmc.init_pet_hmc_wf`
+    * :py:func:`~petprep.workflows.pet.registration.init_pet_reg_wf`
+    * :py:func:`~petprep.workflows.pet.outputs.init_ds_petref_wf`
+    * :py:func:`~petprep.workflows.pet.outputs.init_ds_hmc_wf`
+    * :py:func:`~petprep.workflows.pet.outputs.init_ds_registration_wf`
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
-    from fmriprep.utils.misc import estimate_pet_mem_usage
+    from petprep.utils.misc import estimate_pet_mem_usage
 
     if precomputed is None:
         precomputed = {}
@@ -418,9 +418,9 @@ def init_pet_native_wf(
             :graph2use: orig
             :simple_form: yes
 
-            from fmriprep.workflows.tests import mock_config
+            from petprep.workflows.tests import mock_config
             from fmriprep import config
-            from fmriprep.workflows.pet.fit import init_pet_native_wf
+            from petprep.workflows.pet.fit import init_pet_native_wf
             with mock_config():
                 pet_file = config.execution.bids_dir / "sub-01" / "func" \
                     / "sub-01_task-mixedgamblestask_run-01_pet.nii.gz"

--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -46,7 +46,7 @@ def init_pet_hmc_wf(mem_gb: float, omp_nthreads: int, name: str = 'pet_hmc_wf'):
             :graph2use: orig
             :simple_form: yes
 
-            from fmriprep.workflows.pet import init_pet_hmc_wf
+            from petprep.workflows.pet import init_pet_hmc_wf
             wf = init_pet_hmc_wf(
                 mem_gb=3,
                 omp_nthreads=1)

--- a/petprep/workflows/pet/outputs.py
+++ b/petprep/workflows/pet/outputs.py
@@ -31,9 +31,9 @@ from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransf
 from niworkflows.utils.images import dseg_label
 
 from fmriprep import config
-from fmriprep.config import DEFAULT_MEMORY_MIN_GB
-from fmriprep.interfaces import DerivativesDataSink
-from fmriprep.interfaces.bids import BIDSURI
+from petprep.config import DEFAULT_MEMORY_MIN_GB
+from petprep.interfaces import DerivativesDataSink
+from petprep.interfaces.bids import BIDSURI
 
 
 def prepare_timing_parameters(metadata: dict):
@@ -67,10 +67,10 @@ def prepare_timing_parameters(metadata: dict):
     When SliceTiming is available and used, then ``SliceTimingCorrected`` is ``True``
     and the ``StartTime`` indicates a series offset.
 
-    >>> with mock.patch("fmriprep.config.workflow.ignore", []):
+    >>> with mock.patch("petprep.config.workflow.ignore", []):
     ...     prepare_timing_parameters(dict(RepetitionTime=2, SliceTiming=[0.0, 0.2, 0.4, 0.6]))
     {'RepetitionTime': 2, 'SliceTimingCorrected': True, 'DelayTime': 1.2, 'StartTime': 0.3}
-    >>> with mock.patch("fmriprep.config.workflow.ignore", []):
+    >>> with mock.patch("petprep.config.workflow.ignore", []):
     ...     prepare_timing_parameters(
     ...         dict(VolumeTiming=[0.0, 1.0, 2.0, 5.0, 6.0, 7.0],
     ...              SliceTiming=[0.0, 0.2, 0.4, 0.6, 0.8]))  #doctest: +NORMALIZE_WHITESPACE
@@ -80,10 +80,10 @@ def prepare_timing_parameters(metadata: dict):
     When SliceTiming is available and not used, then ``SliceTimingCorrected`` is ``False``
     and TA is indicated with ``DelayTime`` or ``AcquisitionDuration``.
 
-    >>> with mock.patch("fmriprep.config.workflow.ignore", ["slicetiming"]):
+    >>> with mock.patch("petprep.config.workflow.ignore", ["slicetiming"]):
     ...     prepare_timing_parameters(dict(RepetitionTime=2, SliceTiming=[0.0, 0.2, 0.4, 0.6]))
     {'RepetitionTime': 2, 'SliceTimingCorrected': False, 'DelayTime': 1.2}
-    >>> with mock.patch("fmriprep.config.workflow.ignore", ["slicetiming"]):
+    >>> with mock.patch("petprep.config.workflow.ignore", ["slicetiming"]):
     ...     prepare_timing_parameters(
     ...         dict(VolumeTiming=[0.0, 1.0, 2.0, 5.0, 6.0, 7.0],
     ...              SliceTiming=[0.0, 0.2, 0.4, 0.6, 0.8]))  #doctest: +NORMALIZE_WHITESPACE
@@ -92,10 +92,10 @@ def prepare_timing_parameters(metadata: dict):
 
     If SliceTiming metadata is present but empty, then treat it as missing:
 
-    >>> with mock.patch("fmriprep.config.workflow.ignore", []):
+    >>> with mock.patch("petprep.config.workflow.ignore", []):
     ...     prepare_timing_parameters(dict(RepetitionTime=2, SliceTiming=[]))
     {'RepetitionTime': 2, 'SliceTimingCorrected': False}
-    >>> with mock.patch("fmriprep.config.workflow.ignore", []):
+    >>> with mock.patch("petprep.config.workflow.ignore", []):
     ...     prepare_timing_parameters(dict(RepetitionTime=2, SliceTiming=[0.0]))
     {'RepetitionTime': 2, 'SliceTimingCorrected': False}
 
@@ -765,7 +765,7 @@ def init_pet_preproc_report_wf(
             :graph2use: orig
             :simple_form: yes
 
-            from fmriprep.workflows.pet.resampling import init_pet_preproc_report_wf
+            from petprep.workflows.pet.resampling import init_pet_preproc_report_wf
             wf = init_pet_preproc_report_wf(mem_gb=1, reportlets_dir='.')
 
     Parameters

--- a/petprep/workflows/pet/reference.py
+++ b/petprep/workflows/pet/reference.py
@@ -49,7 +49,7 @@ def init_raw_petref_wf(
             :graph2use: orig
             :simple_form: yes
 
-            from fmriprep.workflows.pet.reference import init_raw_petref_wf
+            from petprep.workflows.pet.reference import init_raw_petref_wf
             wf = init_raw_petref_wf()
 
     Parameters

--- a/petprep/workflows/pet/registration.py
+++ b/petprep/workflows/pet/registration.py
@@ -54,7 +54,7 @@ def init_pet_reg_wf(
             :graph2use: orig
             :simple_form: yes
 
-            from fmriprep.workflows.pet.registration import init_pet_reg_wf
+            from petprep.workflows.pet.registration import init_pet_reg_wf
             wf = init_pet_reg_wf(
                 mem_gb=3,
                 omp_nthreads=1,

--- a/petprep/workflows/pet/resampling.py
+++ b/petprep/workflows/pet/resampling.py
@@ -68,7 +68,7 @@ def init_pet_surf_wf(
             :graph2use: colored
             :simple_form: yes
 
-            from fmriprep.workflows.pet import init_pet_surf_wf
+            from petprep.workflows.pet import init_pet_surf_wf
             wf = init_pet_surf_wf(mem_gb=0.1,
                                    surface_spaces=["fsnative", "fsaverage5"],
                                    medial_surface_nan=False,
@@ -112,7 +112,7 @@ def init_pet_surf_wf(
     from niworkflows.interfaces.nitransforms import ConcatenateXFMs
     from niworkflows.interfaces.surf import GiftiSetAnatomicalStructure
 
-    from fmriprep.interfaces import DerivativesDataSink
+    from petprep.interfaces import DerivativesDataSink
 
     timing_parameters = prepare_timing_parameters(metadata)
 
@@ -263,7 +263,7 @@ def init_pet_fsLR_resampling_wf(
             :graph2use: colored
             :simple_form: yes
 
-            from fmriprep.workflows.pet.resampling import init_pet_fsLR_resampling_wf
+            from petprep.workflows.pet.resampling import init_pet_fsLR_resampling_wf
             wf = init_pet_fsLR_resampling_wf(
                 grayord_density='92k',
                 omp_nthreads=1,
@@ -311,7 +311,7 @@ def init_pet_fsLR_resampling_wf(
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
     from niworkflows.interfaces.utility import KeySelect
 
-    from fmriprep.interfaces.workbench import VolumeToSurfaceMapping
+    from petprep.interfaces.workbench import VolumeToSurfaceMapping
 
     fslr_density = '32k' if grayord_density == '91k' else '59k'
 
@@ -472,7 +472,7 @@ def init_pet_grayords_wf(
             :graph2use: colored
             :simple_form: yes
 
-            from fmriprep.workflows.pet.resampling import init_pet_grayords_wf
+            from petprep.workflows.pet.resampling import init_pet_grayords_wf
             wf = init_pet_grayords_wf(mem_gb=0.1, grayord_density="91k", metadata={"FrameTimesStart": [0, 1], "FrameDuration": [1, 1]})
 
     Parameters
@@ -505,7 +505,7 @@ def init_pet_grayords_wf(
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from fmriprep.interfaces import GeneratePetCifti
+    from petprep.interfaces import GeneratePetCifti
     import numpy as np
 
     workflow = Workflow(name=name)

--- a/petprep/workflows/tests/test_base.py
+++ b/petprep/workflows/tests/test_base.py
@@ -156,7 +156,7 @@ def test_init_petprep_wf(
         config.workflow.run_reconall = freesurfer
         config.workflow.ignore = ignore
         config.workflow.force = force
-        with patch.dict('fmriprep.config.execution.bids_filters', bids_filters):
+        with patch.dict('petprep.config.execution.bids_filters', bids_filters):
             wf = init_petprep_wf()
 
     generate_expanded_graph(wf._create_flat_graph())


### PR DESCRIPTION
## Summary
- update imports that referenced `fmriprep.` to use the new package name
- rename environment variables to `PETPREP_*`
- update help strings and report interfaces to mention PETPrep

## Testing
- `ruff check petprep`
- `pytest` *(fails: unrecognized arguments because pytest-cov is missing)*
