### PR TITLE
Add partial volume correction options

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -41,8 +41,7 @@ def _build_parser(**kwargs):
 
     from .version import check_latest, is_flagged
 
-    deprecations = {
-    }
+    deprecations = {}
 
     class DeprecatedAction(Action):
         def __call__(self, parser, namespace, values, option_string=None):
@@ -151,9 +150,7 @@ def _build_parser(**kwargs):
         try:
             return int(value)
         except ValueError:
-            raise parser.error(
-                "Reference frame must be an integer index or 'average'."
-            ) from None
+            raise parser.error("Reference frame must be an integer index or 'average'.") from None
 
     verstr = f'PETPrep v{config.environment.version}'
     currentv = Version(config.environment.version)
@@ -394,7 +391,7 @@ https://petprep.readthedocs.io/en/%s/spaces.html"""
         type=ReferenceFrame,
         default='average',
         help=(
-            "Reference frame index (0-based) for PET preprocessing. "
+            'Reference frame index (0-based) for PET preprocessing. '
             "Use 'average' to compute the standard averaged reference."
         ),
     )
@@ -558,6 +555,22 @@ https://petprep.readthedocs.io/en/%s/spaces.html"""
         dest='fs_no_resume',
         help='EXPERT: Import pre-computed FreeSurfer reconstruction without resuming. '
         'The user is responsible for ensuring that all necessary files are present.',
+    )
+
+    g_pvc = parser.add_argument_group('Options for partial volume correction')
+    g_pvc.add_argument(
+        '--pvc-method',
+        action='store',
+        default=None,
+        help='Partial volume correction method to apply',
+    )
+    g_pvc.add_argument(
+        '--psf',
+        nargs=3,
+        metavar=('X', 'Y', 'Z'),
+        type=float,
+        default=None,
+        help='Point-spread function full-width at half-maximum in mm',
     )
 
     g_carbon = parser.add_argument_group('Options for carbon usage tracking')

--- a/petprep/cli/workflow.py
+++ b/petprep/cli/workflow.py
@@ -86,7 +86,9 @@ def build_workflow(config_file, retval):
     if config.execution.reports_only:
         build_log.log(25, 'Running --reports-only on participants %s', ', '.join(subject_list))
         session_list = (
-            config.execution.bids_filters.get('pet', config.execution.bids_filters.get('bold', {})).get('session')
+            config.execution.bids_filters.get(
+                'pet', config.execution.bids_filters.get('bold', {})
+            ).get('session')
             if config.execution.bids_filters
             else None
         )
@@ -124,6 +126,18 @@ def build_workflow(config_file, retval):
     build_log.log(25, f'\n{" " * 11}* '.join(init_msg))
 
     retval['workflow'] = init_petprep_wf()
+
+    if config.workflow.pvc_method:
+        try:
+            from ..workflows.pet.pvc import init_pet_pvc_wf
+        except Exception as exc:
+            build_log.warning('Partial volume correction workflow unavailable: %s', exc)
+        else:
+            pvc_wf = init_pet_pvc_wf(
+                pvc_method=config.workflow.pvc_method,
+                psf=config.workflow.psf,
+            )
+            retval['workflow'].add_nodes([pvc_wf])
 
     # Check for FS license after building the workflow
     if not check_valid_fs_license():

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -205,7 +205,7 @@ except Exception:  # noqa: S110, BLE001
 
 # Debug modes are names that influence the exposure of internal details to
 # the user, either through additional derivatives or increased verbosity
-DEBUG_MODES = ('pdb','debug')
+DEBUG_MODES = ('pdb', 'debug')
 
 
 class _Config:
@@ -596,6 +596,13 @@ class workflow(_Config):
     """Selected frame index for PET reference generation.
 
     ``None`` or ``'average'`` retains the current averaging behavior."""
+
+    pvc_method = None
+    """Partial volume correction method."""
+
+    psf: list[float] | None = None
+    """Point-spread function (FWHM) of the acquisition as ``[x, y, z]``."""
+
 
 class loggers:
     """Keep loggers easily accessible (see :py:func:`init`)."""


### PR DESCRIPTION
## Summary
- add `pvc_method` and `psf` workflow options in config
- expose partial volume correction arguments in CLI
- pass new options to PVC workflow during build

## Testing
- `ruff check petprep/config.py petprep/cli/parser.py petprep/cli/workflow.py --diff`
- `ruff format petprep/config.py petprep/cli/parser.py petprep/cli/workflow.py`
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_683df26102088330a2b31362d9ef58e6