### PR TITLE
Add PVC datasinks and parser tests

### DIFF
--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -245,6 +245,31 @@ def test_derivatives(tmp_path):
         parser.parse_args(temp_args)
     _reset_config()
 
+
+def test_pvc_cli_args(tmp_path, minimal_bids):
+    """Check parser handling of PVC options."""
+    out_dir = tmp_path / 'out'
+    work_dir = tmp_path / 'work'
+
+    opts = parse_args(
+        args=[
+            str(minimal_bids),
+            str(out_dir),
+            'participant',
+            '-w',
+            str(work_dir),
+            '--skip-bids-validation',
+            '--pvc-method', 'GTM',
+            '--psf', '1', '2', '3',
+        ]
+    )
+
+    assert opts.pvc_method == 'GTM'
+    assert opts.psf == [1.0, 2.0, 3.0]
+    assert config.workflow.pvc_method == 'GTM'
+    assert config.workflow.psf == [1.0, 2.0, 3.0]
+    _reset_config()
+
     # Providing --derivatives without names should automatically label them
     temp_args = args + ['--derivatives', str(bids_path / 'derivatives/smriprep')]
     opts = parser.parse_args(temp_args)

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -45,6 +45,7 @@ from .fit import init_pet_fit_wf, init_pet_native_wf
 from .outputs import (
     init_ds_pet_native_wf,
     init_ds_volumes_wf,
+    init_ds_pet_pvc_wf,
     prepare_timing_parameters,
 )
 from .pvc import init_pet_pvc_wf
@@ -353,6 +354,20 @@ configured with cubic B-spline interpolation.
         ]),
         (pet_fit_wf, pet_pvc_wf, [
             ('outputnode.petref2anat_xfm', 'inputnode.petref2anat_xfm'),
+        ]),
+    ])  # fmt:skip
+
+    ds_pet_pvc_wf = init_ds_pet_pvc_wf(
+        bids_root=str(config.execution.bids_dir),
+        output_dir=petprep_dir,
+        metadata=all_metadata[0],
+        name='ds_pet_pvc_wf',
+    )
+    ds_pet_pvc_wf.inputs.inputnode.source_files = pet_file
+    workflow.connect([
+        (pet_pvc_wf, ds_pet_pvc_wf, [
+            ('outputnode.pet_pvc', 'inputnode.pet_pvc'),
+            ('outputnode.tac_file', 'inputnode.tac_file'),
         ]),
     ])  # fmt:skip
 

--- a/petprep/workflows/pet/outputs.py
+++ b/petprep/workflows/pet/outputs.py
@@ -749,6 +749,63 @@ def init_ds_volumes_wf(
     return workflow
 
 
+def init_ds_pet_pvc_wf(*, bids_root: str, output_dir: str, metadata: dict, name='ds_pet_pvc_wf') -> pe.Workflow:
+    """Write out partial volume corrected PET and TAC file."""
+
+    timing_parameters = prepare_timing_parameters(metadata)
+
+    workflow = pe.Workflow(name=name)
+    inputnode = pe.Node(
+        niu.IdentityInterface(fields=['source_files', 'pet_pvc', 'tac_file']),
+        name='inputnode',
+    )
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=['pet_pvc', 'tac_file']), name='outputnode'
+    )
+
+    sources = pe.Node(
+        BIDSURI(numinputs=1, dataset_links=config.execution.dataset_links, out_dir=str(output_dir)),
+        name='sources',
+    )
+
+    ds_pet_pvc = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            desc='pvc',
+            datatype='pet',
+            compress=True,
+            TaskName=metadata.get('TaskName'),
+            **timing_parameters,
+        ),
+        name='ds_pet_pvc',
+        mem_gb=DEFAULT_MEMORY_MIN_GB,
+    )
+
+    ds_tac = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            desc='pvc',
+            datatype='pet',
+            suffix='tac',
+            extension='.tsv',
+        ),
+        name='ds_tac',
+        run_without_submitting=True,
+    )
+
+    workflow.connect([
+        (inputnode, sources, [('source_files', 'in1')]),
+        (inputnode, ds_pet_pvc, [('pet_pvc', 'in_file'), ('source_files', 'source_file')]),
+        (inputnode, ds_tac, [('tac_file', 'in_file'), ('source_files', 'source_file')]),
+        (sources, ds_pet_pvc, [('out', 'Sources')]),
+        (sources, ds_tac, [('out', 'Sources')]),
+        (ds_pet_pvc, outputnode, [('out_file', 'pet_pvc')]),
+        (ds_tac, outputnode, [('out_file', 'tac_file')]),
+    ])  # fmt:skip
+
+    return workflow
+
+
 def init_pet_preproc_report_wf(
     mem_gb: float,
     reportlets_dir: str,

--- a/petprep/workflows/pet/tests/test_outputs.py
+++ b/petprep/workflows/pet/tests/test_outputs.py
@@ -11,6 +11,7 @@ from ..outputs import (
     init_ds_petmask_wf,
     init_ds_pet_native_wf,
     init_ds_volumes_wf,
+    init_ds_pet_pvc_wf,
 )
 
 
@@ -46,3 +47,10 @@ def test_datasink_datatype(tmp_path: Path):
         assert wf.get_node("ds_pet").inputs.datatype == "pet"
         assert wf.get_node("ds_ref").inputs.datatype == "pet"
         assert wf.get_node("ds_mask").inputs.datatype == "pet"
+        wf = init_ds_pet_pvc_wf(
+            bids_root=bids_dir,
+            output_dir=out_dir,
+            metadata={},
+        )
+        assert wf.get_node("ds_pet_pvc").inputs.datatype == "pet"
+        assert wf.get_node("ds_tac").inputs.datatype == "pet"


### PR DESCRIPTION
## Summary
- add output workflow for partial volume correction results
- connect PET PVC workflow to datasinks
- extend parser unit tests with PVC options
- cover datasink datatypes for PVC outputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nibabel')*

------
https://chatgpt.com/codex/tasks/task_e_683df2638ae88330815c8de4c0fd85a6