### PR TITLE
Add GTM segmentation CLI option

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -572,6 +572,13 @@ https://petprep.readthedocs.io/en/%s/spaces.html"""
         default=None,
         help='Point-spread function full-width at half-maximum in mm',
     )
+    g_pvc.add_argument(
+        '--seg',
+        action='store_true',
+        dest='generate_seg',
+        default=False,
+        help='Generate GTM segmentation for partial volume correction',
+    )
 
     g_carbon = parser.add_argument_group('Options for carbon usage tracking')
     g_carbon.add_argument(

--- a/petprep/cli/workflow.py
+++ b/petprep/cli/workflow.py
@@ -139,6 +139,15 @@ def build_workflow(config_file, retval):
             )
             retval['workflow'].add_nodes([pvc_wf])
 
+    if config.workflow.generate_seg:
+        try:
+            from ..workflows.pet import init_pet_gtmseg_wf
+        except Exception as exc:
+            build_log.warning('Segmentation workflow unavailable: %s', exc)
+        else:
+            seg_wf = init_pet_gtmseg_wf()
+            retval['workflow'].add_nodes([seg_wf])
+
     # Check for FS license after building the workflow
     if not check_valid_fs_license():
         from ..utils.misc import fips_enabled

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -603,6 +603,9 @@ class workflow(_Config):
     psf: list[float] | None = None
     """Point-spread function (FWHM) of the acquisition as ``[x, y, z]``."""
 
+    generate_seg = False
+    """Run workflow to generate GTM segmentation."""
+
 
 class loggers:
     """Keep loggers easily accessible (see :py:func:`init`)."""


### PR DESCRIPTION
## Summary
- allow generating GTM segmentation via `--seg`
- store `generate_seg` in the workflow configuration
- enable segmentation workflow in the CLI

## Testing
- `ruff check petprep/cli/parser.py petprep/config.py petprep/cli/workflow.py --diff`
- `ruff format petprep/cli/parser.py petprep/config.py petprep/cli/workflow.py --diff`
- `pytest -k parser --override-ini addopts='' -q` *(fails: ModuleNotFoundError: No module named 'fmriprep' and network issues)*

------
https://chatgpt.com/codex/tasks/task_e_683e02a4c730833097ec6f49c2bd2bcd