### PR TITLE
Add GTMSeg interface and workflow

### DIFF
--- a/petprep/interfaces/__init__.py
+++ b/petprep/interfaces/__init__.py
@@ -3,6 +3,7 @@
 from niworkflows.interfaces.bids import DerivativesDataSink as _DDSink
 
 from .cifti import GeneratePetCifti
+from .gtmseg import GTMSeg
 from .pvc import PETPVC, PVCMake4D
 
 
@@ -15,4 +16,5 @@ __all__ = (
     'GeneratePetCifti',
     'PETPVC',
     'PVCMake4D',
+    'GTMSeg',
 )

--- a/petprep/interfaces/gtmseg.py
+++ b/petprep/interfaces/gtmseg.py
@@ -1,0 +1,8 @@
+from nipype.interfaces.freesurfer import GTMSeg as _GTMSeg
+
+
+class GTMSeg(_GTMSeg):
+    """Thin wrapper around Nipype's :class:`~nipype.interfaces.freesurfer.GTMSeg`."""
+
+
+__all__ = ('GTMSeg',)

--- a/petprep/workflows/pet/__init__.py
+++ b/petprep/workflows/pet/__init__.py
@@ -19,10 +19,12 @@ from .confounds import init_pet_confs_wf
 from .hmc import init_pet_hmc_wf
 from .registration import init_pet_reg_wf
 from .resampling import init_pet_surf_wf
+from .seg import init_pet_gtmseg_wf
 
 __all__ = [
     'init_pet_confs_wf',
     'init_pet_hmc_wf',
     'init_pet_reg_wf',
     'init_pet_surf_wf',
+    'init_pet_gtmseg_wf',
 ]

--- a/petprep/workflows/pet/seg.py
+++ b/petprep/workflows/pet/seg.py
@@ -1,0 +1,28 @@
+from nipype.interfaces import utility as niu
+from nipype.pipeline import engine as pe
+
+from ...interfaces import GTMSeg
+
+
+def init_pet_gtmseg_wf(name: str = 'pet_gtmseg_wf') -> pe.Workflow:
+    """Generate GTM segmentation from FreeSurfer reconstructions."""
+
+    workflow = pe.Workflow(name=name)
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(fields=['subjects_dir', 'subject_id']),
+        name='inputnode',
+    )
+
+    outputnode = pe.Node(niu.IdentityInterface(fields=['gtmseg']), name='outputnode')
+
+    gtmseg = pe.Node(GTMSeg(), name='gtmseg')
+
+    workflow.connect(
+        [
+            (inputnode, gtmseg, [('subjects_dir', 'subjects_dir'), ('subject_id', 'subject_id')]),
+            (gtmseg, outputnode, [('out_file', 'gtmseg')]),
+        ]
+    )
+
+    return workflow

--- a/petprep/workflows/pet/tests/test_seg.py
+++ b/petprep/workflows/pet/tests/test_seg.py
@@ -1,0 +1,12 @@
+from ..seg import init_pet_gtmseg_wf
+
+
+def test_gtmseg_connections():
+    wf = init_pet_gtmseg_wf()
+
+    edge_in = wf._graph.get_edge_data(wf.get_node('inputnode'), wf.get_node('gtmseg'))
+    assert ('subjects_dir', 'subjects_dir') in edge_in['connect']
+    assert ('subject_id', 'subject_id') in edge_in['connect']
+
+    edge_out = wf._graph.get_edge_data(wf.get_node('gtmseg'), wf.get_node('outputnode'))
+    assert ('out_file', 'gtmseg') in edge_out['connect']


### PR DESCRIPTION
## Summary
- add GTMSeg interface wrapping nipype implementation
- create workflow to run GTMSeg
- expose workflow and interface in package
- test workflow connections

## Testing
- `ruff check --fix petprep/workflows/pet/__init__.py petprep/interfaces/__init__.py petprep/interfaces/gtmseg.py petprep/workflows/pet/seg.py petprep/workflows/pet/tests/test_seg.py`
- `pytest -q -p no:cov --override-ini addopts='' petprep/workflows/pet/tests/test_seg.py::test_gtmseg_connections` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_683e02a2437483308d9849cb30036b60