### PR TITLE
Add GTM TAC extraction workflow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,7 @@ All merged pull requests
 * ENH: Output fsLR meshes on subject surfaces (#3411)
 * ENH: Flexibilize "sophisticated" pepolar to allow monomodal execution (#3393)
 * ENH: Update FSL packages for reported bug fixes (#3374)
+* ENH: Generate time-activity curves from GTM segmentations
 * RF: Calculate RMSD from motion transforms (#3427)
 * RF: Reconstruct motion confounds from minimal derivatives (#3424)
 * RF: Replace deprecated pkgutil.find_loader (#3384)

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -296,6 +296,8 @@ This file is resampled to match the orientation and resolution of the native
 T1-weighted images. The segmentation statistics are stored in
 ``sub-<subject_label>/anat/sub-<subject_label>_desc-gtm_dseg.tsv`` and
 ``sub-<subject_label>/anat/sub-<subject_label>_desc-gtm_morph.tsv``.
+``sub-<subject_label>/pet/sub-<subject_label>_desc-gtm_tacs.tsv`` stores the
+time-activity curves extracted from the GTM regions.
 
 Surface output spaces include ``fsnative`` (full density subject-specific mesh),
 ``fsaverage`` and the down-sampled meshes ``fsaverage6`` (41k vertices) and

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -190,7 +190,8 @@ and ``limbic``.
 Using ``--seg gtm`` runs FreeSurfer's ``gtmseg`` command to create a
 directory. The segmentation is resampled to match the native anatomical image
 resolution. It also generates ``desc-gtm_dseg.tsv`` and ``desc-gtm_morph.tsv``
-tables containing segmentation statistics.
+tables containing segmentation statistics. A ``desc-gtm_tacs.tsv`` file with
+time-activity curves is written to the ``pet`` derivatives directory.
 
 Troubleshooting
 ---------------

--- a/petprep/interfaces/__init__.py
+++ b/petprep/interfaces/__init__.py
@@ -3,6 +3,7 @@
 from niworkflows.interfaces.bids import DerivativesDataSink as _DDSink
 
 from .cifti import GeneratePetCifti
+from .tacs import ExtractTACs
 
 
 class DerivativesDataSink(_DDSink):
@@ -12,4 +13,5 @@ class DerivativesDataSink(_DDSink):
 __all__ = (
     'DerivativesDataSink',
     'GeneratePetCifti',
+    'ExtractTACs',
 )

--- a/petprep/interfaces/tacs.py
+++ b/petprep/interfaces/tacs.py
@@ -1,0 +1,88 @@
+import nibabel as nb
+import numpy as np
+import pandas as pd
+from nipype.interfaces.base import (
+    BaseInterfaceInputSpec,
+    File,
+    SimpleInterface,
+    TraitedSpec,
+    traits,
+)
+from nipype.utils.filemanip import fname_presuffix
+
+
+class ExtractTACsInputSpec(BaseInterfaceInputSpec):
+    pet_file = File(exists=True, mandatory=True, desc='4D PET series')
+    segmentation = File(exists=True, mandatory=True, desc='Segmentation in PET space')
+    dseg_tsv = File(exists=True, mandatory=True, desc='Segmentation TSV file')
+    metadata = traits.Dict(desc='PET metadata')
+    out_file = File(desc='Output TSV file')
+
+
+class ExtractTACsOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='Extracted TACs TSV file')
+
+
+class ExtractTACs(SimpleInterface):
+    """Extract time-activity curves from a segmentation."""
+
+    input_spec = ExtractTACsInputSpec
+    output_spec = ExtractTACsOutputSpec
+
+    def _run_interface(self, runtime):
+        pet_img = nb.load(self.inputs.pet_file)
+        seg_img = nb.load(self.inputs.segmentation)
+
+        pet_data = np.asanyarray(pet_img.dataobj)
+        seg_data = np.asanyarray(seg_img.dataobj).astype(int)
+
+        df_labels = pd.read_csv(self.inputs.dseg_tsv, sep='\t')
+        labels = df_labels.iloc[:, 0].astype(int).to_list()
+        names = df_labels['name'].to_list()
+
+        nframes = pet_data.shape[3]
+        meta = self.inputs.metadata or {}
+        frame_starts = meta.get('FrameTimesStart')
+        frame_durs = meta.get('FrameDuration')
+
+        if frame_starts is None:
+            frame_starts = list(range(nframes))
+        if frame_durs is None:
+            frame_durs = [1] * nframes
+
+        frame_starts = frame_starts[:nframes]
+        frame_durs = frame_durs[:nframes]
+        frame_ends = [s + d for s, d in zip(frame_starts, frame_durs, strict=False)]
+
+        out_df = pd.DataFrame(
+            {
+                'FrameTimeStart': frame_starts,
+                'FrameTimesEnd': frame_ends,
+            }
+        )
+
+        flat_pet = pet_data.reshape(-1, nframes)
+        flat_seg = seg_data.reshape(-1)
+        for label, name in zip(labels, names, strict=False):
+            mask = flat_seg == label
+            if not np.any(mask):
+                out_df[name] = [np.nan] * nframes
+            else:
+                out_df[name] = flat_pet[mask].mean(axis=0)
+
+        out_file = self.inputs.out_file
+        if not out_file:
+            out_file = (
+                fname_presuffix(
+                    self.inputs.pet_file,
+                    suffix='_tacs',
+                    newpath=runtime.cwd,
+                    use_ext=False,
+                )
+                + '.tsv'
+            )
+
+        out_df.to_csv(out_file, sep='\t', index=False, float_format='%.8g')
+        self._results['out_file'] = out_file
+        return runtime
+

--- a/petprep/interfaces/tests/test_tacs.py
+++ b/petprep/interfaces/tests/test_tacs.py
@@ -1,0 +1,42 @@
+import nibabel as nb
+import numpy as np
+import pandas as pd
+from nipype.pipeline import engine as pe
+
+from petprep.interfaces.tacs import ExtractTACs
+
+
+def test_extract_tacs(tmp_path):
+    pet_data = np.zeros((2, 2, 2, 2), dtype=float)
+    seg = np.array(
+        [
+            [[1, 1], [2, 2]],
+            [[1, 1], [2, 2]],
+        ]
+    )
+    pet_data[..., 0] = seg
+    pet_data[..., 1] = seg * 2
+    pet_file = tmp_path / 'pet.nii.gz'
+    seg_file = tmp_path / 'seg.nii.gz'
+    dseg_tsv = tmp_path / 'dseg.tsv'
+
+    nb.Nifti1Image(pet_data, np.eye(4)).to_filename(pet_file)
+    nb.Nifti1Image(seg, np.eye(4)).to_filename(seg_file)
+    pd.DataFrame({'index': [1, 2], 'name': ['region1', 'region2']}).to_csv(
+        dseg_tsv, sep='\t', index=False
+    )
+
+    node = pe.Node(
+        ExtractTACs(metadata={'FrameTimesStart': [0, 1], 'FrameDuration': [1, 1]}),
+        name='tacs',
+        base_dir=tmp_path,
+    )
+    node.inputs.pet_file = str(pet_file)
+    node.inputs.segmentation = str(seg_file)
+    node.inputs.dseg_tsv = str(dseg_tsv)
+    res = node.run()
+
+    out_df = pd.read_csv(res.outputs.out_file, sep='\t')
+    assert list(out_df.columns) == ['FrameTimeStart', 'FrameTimesEnd', 'region1', 'region2']
+    assert np.allclose(out_df['region1'], [1, 2])
+    assert np.allclose(out_df['region2'], [2, 4])

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -37,7 +37,6 @@ from niworkflows.utils.connections import listify
 from ... import config
 from ...interfaces import DerivativesDataSink
 from ...utils.misc import estimate_pet_mem_usage
-from .segmentation import init_segmentation_wf
 
 # PET workflows
 from .apply import init_pet_volumetric_resample_wf
@@ -49,6 +48,8 @@ from .outputs import (
     prepare_timing_parameters,
 )
 from .resampling import init_pet_surf_wf
+from .segmentation import init_segmentation_wf
+from .tacs import init_gtm_tacs_wf
 
 
 def init_pet_wf(
@@ -324,6 +325,16 @@ configured with cubic B-spline interpolation.
         (pet_native_wf, pet_anat_wf, [
             ('outputnode.pet_minimal', 'inputnode.pet_file'),
             ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
+        ]),
+    ])  # fmt:skip
+
+    gtm_tacs_wf = init_gtm_tacs_wf(metadata=all_metadata[0])
+
+    workflow.connect([
+        (pet_anat_wf, gtm_tacs_wf, [('outputnode.pet_file', 'inputnode.pet')]),
+        (seg_wf, gtm_tacs_wf, [
+            ('outputnode.segmentation', 'inputnode.segmentation'),
+            ('outputnode.dseg_tsv', 'inputnode.dseg_tsv'),
         ]),
     ])  # fmt:skip
 

--- a/petprep/workflows/pet/tacs.py
+++ b/petprep/workflows/pet/tacs.py
@@ -1,0 +1,77 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+"""Workflow to extract time-activity curves."""
+
+from __future__ import annotations
+
+from nipype.interfaces import utility as niu
+from nipype.pipeline import engine as pe
+from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+
+from ... import config
+from ...config import DEFAULT_MEMORY_MIN_GB
+from ...interfaces import DerivativesDataSink, ExtractTACs
+from ...interfaces.bids import BIDSURI
+from .outputs import prepare_timing_parameters
+
+
+def init_gtm_tacs_wf(metadata: dict, name: str = 'gtm_tacs_wf') -> Workflow:
+    """Generate TACs from a GTM segmentation."""
+
+    timing_parameters = prepare_timing_parameters(metadata)
+
+    workflow = Workflow(name=name)
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(fields=['pet', 'segmentation', 'dseg_tsv']),
+        name='inputnode',
+    )
+    outputnode = pe.Node(niu.IdentityInterface(fields=['out_file']), name='outputnode')
+
+    sources = pe.Node(
+        BIDSURI(
+            numinputs=1,
+            dataset_links=config.execution.dataset_links,
+            out_dir=str(config.execution.petprep_dir),
+        ),
+        name='sources',
+    )
+
+    extract = pe.Node(
+        ExtractTACs(metadata=timing_parameters),
+        name='extract_tacs',
+    )
+
+    ds_tacs = pe.Node(
+        DerivativesDataSink(
+            base_directory=config.execution.petprep_dir,
+            desc='gtm',
+            suffix='tacs',
+            extension='.tsv',
+            datatype='pet',
+            check_hdr=False,
+        ),
+        name='ds_gtmtacs',
+        run_without_submitting=True,
+        mem_gb=DEFAULT_MEMORY_MIN_GB,
+    )
+
+    workflow.connect(
+        [
+            (inputnode, sources, [('pet', 'in1')]),
+            (
+                inputnode,
+                extract,
+                [
+                    ('pet', 'pet_file'),
+                    ('segmentation', 'segmentation'),
+                    ('dseg_tsv', 'dseg_tsv'),
+                ],
+            ),
+            (extract, ds_tacs, [('out_file', 'in_file')]),
+            (inputnode, ds_tacs, [('pet', 'source_file')]),
+            (sources, ds_tacs, [('out', 'Sources')]),
+            (ds_tacs, outputnode, [('out_file', 'out_file')]),
+        ]
+    )
+
+    return workflow

--- a/petprep/workflows/pet/tests/test_segmentation.py
+++ b/petprep/workflows/pet/tests/test_segmentation.py
@@ -38,8 +38,9 @@ def test_segmentation_branch(bids_root: Path, tmp_path: Path, seg: str):
 
     if seg == 'gtm':
         run_gtm = seg_wf.get_node('run_gtm')
-        from nipype.interfaces.freesurfer.petsurfer import GTMSeg
         from nipype.interfaces.freesurfer import MRIConvert
+        from nipype.interfaces.freesurfer.petsurfer import GTMSeg
+
         from ....interfaces import DerivativesDataSink
 
         assert isinstance(run_gtm.interface, GTMSeg)
@@ -62,6 +63,8 @@ def test_segmentation_branch(bids_root: Path, tmp_path: Path, seg: str):
         assert dseg_tsv.interface.inputs.suffix == 'dseg'
         assert dseg_tsv.interface.inputs.extension == '.tsv'
         assert dseg_tsv.interface.inputs.datatype == 'anat'
+        outnode = seg_wf.get_node('outputnode')
+        assert hasattr(outnode.outputs, 'dseg_tsv')
         assert isinstance(morph_tsv.interface, DerivativesDataSink)
         assert morph_tsv.interface.inputs.desc == 'gtm'
         assert morph_tsv.interface.inputs.suffix == 'morph'

--- a/petprep/workflows/pet/tests/test_tacs.py
+++ b/petprep/workflows/pet/tests/test_tacs.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import nibabel as nb
+import numpy as np
+from niworkflows.utils.testing import generate_bids_skeleton
+
+from .... import config
+from ...tests import mock_config
+from ...tests.test_base import BASE_LAYOUT
+from ..base import init_pet_wf
+
+
+def _prep_bids(tmp_path: Path) -> Path:
+    bids_dir = tmp_path / 'bids'
+    generate_bids_skeleton(bids_dir, BASE_LAYOUT)
+    img = nb.Nifti1Image(np.zeros((2, 2, 2, 2)), np.eye(4))
+    for p in bids_dir.rglob('*.nii.gz'):
+        img.to_filename(p)
+    return bids_dir
+
+
+def test_gtm_tacs_wf(tmp_path: Path):
+    bids_dir = _prep_bids(tmp_path)
+    pet_series = [str(bids_dir / 'sub-01' / 'pet' / 'sub-01_task-rest_run-1_pet.nii.gz')]
+    with mock_config(bids_dir=bids_dir):
+        config.workflow.seg = 'gtm'
+        wf = init_pet_wf(pet_series=pet_series, precomputed={})
+
+    tacs_wf = wf.get_node('gtm_tacs_wf')
+    assert tacs_wf is not None
+
+    ds = tacs_wf.get_node('ds_gtmtacs')
+    from ....interfaces import DerivativesDataSink
+
+    assert isinstance(ds.interface, DerivativesDataSink)
+    assert ds.interface.inputs.datatype == 'pet'


### PR DESCRIPTION
## Summary
- implement `ExtractTACs` interface for computing time–activity curves
- expose `dseg_tsv` from segmentation workflow
- add `gtm_tacs_wf` to compute and save TACs
- integrate TAC extraction into the PET workflow
- document new outputs and CLI behavior
- include unit tests for interface and workflow

## Testing
- `ruff check --fix` and `ruff format` used for linting
- `pytest -q` *(fails: unrecognized arguments --cov=petprep --cov-report=xml --cov-config=pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68454e1016b083309d3df36b5704bb82