### PR TITLE
Add atlas-based segmentation options for subcortex and hammers

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -210,10 +210,13 @@ Segmentation
 ----------------
 *PETPrep* can segment the brain into different brain regions and extract time activity curves from these regions.
 The ``--seg`` flag selects the segmentation method to use.
-Available options are ``gtm`` (default) whole-brain segmentation from freesurfer, ``brainstem``, ``wm`` (white matter), ``thalamicNuclei``, ``hippocampusAmygdala``, ``raphe``, and ``limbic``.
+Available options are ``gtm`` (default) whole-brain segmentation from freesurfer, ``brainstem``, ``wm`` (white matter), ``thalamicNuclei``, ``hippocampusAmygdala``, ``raphe``, ``limbic``, ``subcortex`` and ``hammers``.
 
 The ``gtm`` segmentation is a whole-brain segmentation that includes the
-cerebral cortex, subcortical structures, and cerebellum.
+cerebral cortex, subcortical structures, and cerebellum. Atlas-based
+segmentations (``subcortex`` and ``hammers``) are registered to their
+native template before being transformed back to the individual anatomy,
+so they can be used interchangeably with the FreeSurfer-derived outputs.
 
 To run the segmentation with the default ``gtm`` method, use: ::
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -549,15 +549,18 @@ Segmentation workflows
 
 *PETPrep* ships with optional segmentation routines that can be selected via
 the ``--seg`` command-line argument. Supported values are ``gtm`` (the default),
-``brainstem``, ``thalamicNuclei``, ``hippocampusAmygdala``, ``wm``, ``raphe`` and
-``limbic``.
+``brainstem``, ``thalamicNuclei``, ``hippocampusAmygdala``, ``wm``, ``raphe``,
+``limbic``, ``subcortex`` and ``hammers``.
 
 These workflows rely on pretrained segmentation models distributed with
 ``petprep.data.segmentation``. The first time a particular model is requested it
 will be automatically downloaded to the *PETPrep* cache directory, so ensure
-sufficient disk space is available. Each segmentation produces a labeled NIfTI
-image ``seg-<seg>_dseg.nii.gz`` and a TSV table of region volumes
-``seg-<seg>_morph.tsv`` saved under the ``anat/`` derivatives folder.
+sufficient disk space is available. Atlas-driven options (``subcortex`` and
+``hammers``) are first registered to their native template space before being
+warped back to the subject anatomy, enabling the atlases to be used alongside
+other segmentations. Each segmentation produces a labeled NIfTI image
+``seg-<seg>_dseg.nii.gz`` and a TSV table of region volumes ``seg-<seg>_morph.tsv``
+saved under the ``anat/`` derivatives folder.
 
 Reference masks generated via ``--ref-mask-name`` create a similar
 ``label-<name>_desc-ref_morph.tsv`` file. These TSVs share the same columns as the

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -572,6 +572,8 @@ https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'lat
             'wm',
             'raphe',
             'limbic',
+            'subcortex',
+            'hammers',
         ],
         help='Segmentation method to use.',
     )

--- a/petprep/utils/segmentation.py
+++ b/petprep/utils/segmentation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 
@@ -174,5 +175,57 @@ def ctab_to_dsegtsv(ctab_file: str) -> str:
     ctab_file = Path(ctab_file)
     df = pd.read_csv(ctab_file, header=None, sep=r'\s+', usecols=[0, 1], names=['index', 'name'])
     out_file = ctab_file.with_suffix('.tsv')
+    df.to_csv(out_file, sep='\t', index=False)
+    return str(out_file)
+
+
+def atlas_copy_dsegtsv(
+    subjects_dir: str,
+    subject_id: str,
+    seg_file: str,
+    *,
+    labels_file: str,
+    seg: str,
+) -> str:
+    """Copy a static atlas label table next to the generated segmentation."""
+
+    import shutil
+
+    seg_path = Path(seg_file)
+    out_file = seg_path.with_name(f'{seg}_dseg.tsv')
+    shutil.copyfile(labels_file, out_file)
+    return str(out_file)
+
+
+def atlas_seg_to_stats(
+    subjects_dir: str,
+    subject_id: str,
+    seg_file: str,
+    *,
+    labels_file: str,
+    seg: str,
+) -> str:
+    """Generate a TSV table with atlas-derived ROI volumes."""
+
+    import nibabel as nb
+
+    seg_path = Path(seg_file)
+    atlas_img = nb.load(seg_path)
+    data = np.rint(atlas_img.get_fdata()).astype(np.int16)
+    zooms = atlas_img.header.get_zooms()
+    voxel_volume = float(np.prod(zooms[:3]))
+
+    labels = pd.read_csv(labels_file, sep='\t')
+    if 'index' not in labels or 'name' not in labels:
+        raise ValueError(f'Atlas label table {labels_file} lacks required columns')
+
+    volumes = []
+    for index, name in labels[['index', 'name']].itertuples(index=False):
+        idx = int(index)
+        count = int(np.count_nonzero(data == idx))
+        volumes.append({'index': idx, 'name': name, 'volume-mm3': count * voxel_volume})
+
+    df = pd.DataFrame(volumes).sort_values('index').reset_index(drop=True)
+    out_file = seg_path.with_name(f'{seg}_morph.tsv')
     df.to_csv(out_file, sep='\t', index=False)
     return str(out_file)

--- a/petprep/workflows/pet/segmentation.py
+++ b/petprep/workflows/pet/segmentation.py
@@ -3,9 +3,11 @@
 
 from nipype import Function
 from nipype.interfaces import utility as niu
+from nipype.interfaces.ants import Registration
 from nipype.interfaces.freesurfer import MRIConvert
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 
 from ... import config
 from ...data import load as load_data
@@ -21,6 +23,8 @@ from ...interfaces.segmentation import (
     SegStats,
 )
 from ...utils.segmentation import (
+    atlas_copy_dsegtsv,
+    atlas_seg_to_stats,
     ctab_to_dsegtsv,
     gtm_stats_to_stats,
     gtm_to_dsegtsv,
@@ -56,6 +60,28 @@ def _merge_ha_labels(lh_file: str, rh_file: str) -> str:
     out_img.set_data_dtype(np.int16)
 
     out_file = Path('hippocampusAmygdala_dseg.nii.gz').absolute()
+    out_img.to_filename(out_file)
+    return str(out_file)
+
+
+def _cast_segmentation(seg_file: str) -> str:
+    """Round segmentation labels to integers and enforce ``int16`` dtype."""
+
+    from pathlib import Path
+
+    import nibabel as nb
+    import numpy as np
+
+    seg_path = Path(seg_file)
+    seg_img = nb.load(seg_path)
+    data = np.rint(seg_img.get_fdata()).astype(np.int16)
+
+    out_img = seg_img.__class__(data, seg_img.affine, seg_img.header)
+    out_img.set_data_dtype(np.int16)
+
+    suffix = ''.join(seg_path.suffixes)
+    stem = seg_path.name[: -len(suffix)] if suffix else seg_path.name
+    out_file = seg_path.with_name(f'{stem}_int16.nii.gz')
     out_img.to_filename(out_file)
     return str(out_file)
 
@@ -119,6 +145,62 @@ SEGMENTATIONS = {
         'inputs': [('t1w_preproc', 'in_file')],
         'color_table': str(load_data('segmentation/sclimbic_cleaned.ctab')),
     },
+    'subcortex': {
+        'desc': 'subcortex',
+        'atlas': {
+            'template': str(
+                load_data(
+                    'segmentation/subcortex/tpl-MNI152NLin2009bAsym_res-1_desc-brain_T1w.nii.gz'
+                )
+            ),
+            'dseg': str(
+                load_data(
+                    'segmentation/subcortex/tpl-MNI152NLin2009bAsym_res-1_desc-brain_dseg.nii.gz'
+                )
+            ),
+            'labels': str(
+                load_data(
+                    'segmentation/subcortex/tpl-MNI152NLin2009bAsym_res-1_desc-brain_dseg.tsv'
+                )
+            ),
+        },
+        'segstats': False,
+        'skip_conversion': True,
+        'dseg_func': atlas_copy_dsegtsv,
+        'dseg_kwargs': {
+            'labels_file': str(
+                load_data('segmentation/subcortex/tpl-MNI152NLin2009bAsym_res-1_desc-brain_dseg.tsv')
+            ),
+            'seg': 'subcortex',
+        },
+        'morph_func': atlas_seg_to_stats,
+        'morph_kwargs': {
+            'labels_file': str(
+                load_data('segmentation/subcortex/tpl-MNI152NLin2009bAsym_res-1_desc-brain_dseg.tsv')
+            ),
+            'seg': 'subcortex',
+        },
+    },
+    'hammers': {
+        'desc': 'hammers',
+        'atlas': {
+            'template': str(load_data('segmentation/hammers/tpl-SPM_space-MNI152_desc-brain_T1w.nii.gz')),
+            'dseg': str(load_data('segmentation/hammers/tpl-SPM_space-MNI152_desc-brain_dseg.nii.gz')),
+            'labels': str(load_data('segmentation/hammers/tpl-SPM_space-MNI152_desc-brain_dseg.tsv')),
+        },
+        'segstats': False,
+        'skip_conversion': True,
+        'dseg_func': atlas_copy_dsegtsv,
+        'dseg_kwargs': {
+            'labels_file': str(load_data('segmentation/hammers/tpl-SPM_space-MNI152_desc-brain_dseg.tsv')),
+            'seg': 'hammers',
+        },
+        'morph_func': atlas_seg_to_stats,
+        'morph_kwargs': {
+            'labels_file': str(load_data('segmentation/hammers/tpl-SPM_space-MNI152_desc-brain_dseg.tsv')),
+            'seg': 'hammers',
+        },
+    },
 }
 
 
@@ -131,6 +213,9 @@ def _build_nodes(
     merge_ha: bool = False,
     dseg_func=ctab_to_dsegtsv,
     morph_func=summary_to_stats,
+    skip_conversion: bool = False,
+    dseg_kwargs: dict | None = None,
+    morph_kwargs: dict | None = None,
 ):
     """Create common segmentation nodes."""
     nodes = {}
@@ -150,11 +235,13 @@ def _build_nodes(
             name='merge_ha_seg',
         )
         seg_source = nodes['merge_seg']
-    else:
+    elif not skip_conversion:
         nodes['convert_seg'] = pe.Node(
             MRIConvert(out_type='niigz', resample_type='nearest'), name=f'convert_{seg}seg'
         )
         seg_source = nodes['convert_seg']
+    else:
+        seg_source = None
 
     nodes['sources'] = pe.Node(
         BIDSURI(
@@ -199,10 +286,16 @@ def _build_nodes(
             name=f'create_{seg}_dsegtsv',
         )
     else:
+        dseg_kwargs = dseg_kwargs or {}
+        morph_kwargs = morph_kwargs or {}
+
+        dseg_inputs = ['subjects_dir', 'subject_id', 'seg_file'] + list(dseg_kwargs.keys())
+        morph_inputs = ['subjects_dir', 'subject_id', 'seg_file'] + list(morph_kwargs.keys())
+
         nodes['make_dseg'] = pe.Node(
             niu.Function(
                 function=dseg_func,
-                input_names=['subjects_dir', 'subject_id', 'seg_file'],
+                input_names=dseg_inputs,
                 output_names=['out_file'],
             ),
             name=f'make_{seg}dsegtsv',
@@ -210,11 +303,16 @@ def _build_nodes(
         nodes['make_morph'] = pe.Node(
             niu.Function(
                 function=morph_func,
-                input_names=['subjects_dir', 'subject_id', 'seg_file'],
+                input_names=morph_inputs,
                 output_names=['out_file'],
             ),
             name=f'make_{seg}morphtsv',
         )
+
+        for key, value in dseg_kwargs.items():
+            setattr(nodes['make_dseg'].inputs, key, value)
+        for key, value in morph_kwargs.items():
+            setattr(nodes['make_morph'].inputs, key, value)
 
     nodes['ds_dseg_tsv'] = pe.Node(
         DerivativesDataSink(
@@ -268,11 +366,70 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
         workflow.connect([(seg_node, outputnode, [('segmentation', 'segmentation')])])
         return workflow
 
-    interface = spec['interface']
-    seg_node = pe.Node(interface(**spec.get('interface_kwargs', {})), name=f'run_{seg}')
+    atlas_spec = spec.get('atlas')
 
-    for in_field, out_field in spec.get('inputs', []):
-        workflow.connect([(inputnode, seg_node, [(in_field, out_field)])])
+    if atlas_spec:
+        reg_node = pe.Node(
+            Registration(
+                fixed_image=atlas_spec['template'],
+                transforms=['Rigid', 'Affine', 'SyN'],
+                transform_parameters=[(0.1,), (0.1,), (0.1, 3, 0)],
+                metric=['MI', 'MI', 'CC'],
+                metric_weight=[1, 1, 1],
+                radius_or_number_of_bins=[32, 32, 4],
+                sampling_strategy=['Regular', 'Regular', None],
+                sampling_percentage=[0.25, 0.25, 1],
+                convergence_threshold=[1e-6, 1e-6, 1e-6],
+                convergence_window_size=[10, 10, 10],
+                smoothing_sigmas=[[3, 2, 1, 0], [3, 2, 1, 0], [3, 2, 1, 0]],
+                shrink_factors=[[8, 4, 2, 1], [8, 4, 2, 1], [8, 4, 2, 1]],
+                use_histogram_matching=[False, False, True],
+                winsorize_lower_quantile=0.005,
+                winsorize_upper_quantile=0.995,
+                initial_moving_transform_com=True,
+                write_composite_transform=True,
+                collapse_output_transforms=True,
+                output_warped_image=False,
+                num_threads=config.nipype.omp_nthreads,
+            ),
+            name=f'{seg}_atlas_reg',
+        )
+
+        apply_node = pe.Node(
+            ApplyTransforms(
+                interpolation='MultiLabel',
+                input_image=atlas_spec['dseg'],
+                output_image=f'{seg}_atlas_to_t1w.nii.gz',
+                num_threads=config.nipype.omp_nthreads,
+            ),
+            name=f'{seg}_atlas_to_native',
+        )
+
+        cast_node = pe.Node(
+            Function(
+                input_names=['in_file'],
+                output_names=['out_file'],
+                function=_cast_segmentation,
+            ),
+            name=f'cast_{seg}_seg',
+        )
+
+        workflow.connect(
+            [
+                (inputnode, reg_node, [('t1w_preproc', 'moving_image')]),
+                (inputnode, apply_node, [('t1w_preproc', 'reference_image')]),
+                (reg_node, apply_node, [('inverse_composite_transform', 'transforms')]),
+                (apply_node, cast_node, [('output_image', 'in_file')]),
+            ]
+        )
+
+        seg_node = cast_node
+    else:
+        interface = spec['interface']
+        seg_node = pe.Node(interface(**spec.get('interface_kwargs', {})), name=f'run_{seg}')
+
+        for in_field, out_field in spec.get('inputs', []):
+            workflow.connect([(inputnode, seg_node, [(in_field, out_field)])])
 
     nodes = _build_nodes(
         seg,
@@ -282,8 +439,13 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
         merge_ha=spec.get('merge_ha', False),
         dseg_func=spec.get('dseg_func', ctab_to_dsegtsv),
         morph_func=spec.get('morph_func', summary_to_stats),
+        skip_conversion=spec.get('skip_conversion', False),
+        dseg_kwargs=spec.get('dseg_kwargs'),
+        morph_kwargs=spec.get('morph_kwargs'),
     )
 
+    if atlas_spec:
+        nodes['seg_source'] = seg_node
     if spec.get('merge_ha', False):
         workflow.connect(
             [
@@ -295,7 +457,7 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
                 (nodes['convert_rh'], nodes['merge_seg'], [('out_file', 'rh_file')]),
             ]
         )
-    else:
+    elif not spec.get('skip_conversion', False):
         workflow.connect(
             [
                 (seg_node, nodes['convert_seg'], [('out_file', 'in_file')]),

--- a/petprep/workflows/pet/tests/test_segmentation.py
+++ b/petprep/workflows/pet/tests/test_segmentation.py
@@ -65,3 +65,16 @@ def test_gtm_connections():
 
         assert ('out_file', 'seg_file') in edge_dseg['connect']
         assert ('out_file', 'seg_file') in edge_morph['connect']
+
+
+def test_atlas_segmentation_nodes():
+    """Atlas-based segmentations should add registration and casting nodes."""
+
+    with mock_config():
+        wf = init_segmentation_wf('subcortex')
+        node_names = {node.name for node in wf._get_all_nodes()}
+
+        assert 'subcortex_atlas_reg' in node_names
+        assert 'subcortex_atlas_to_native' in node_names
+        assert 'cast_subcortex_seg' in node_names
+        assert 'convert_subcortexseg' not in node_names


### PR DESCRIPTION
## Summary
- add atlas-backed subcortex and hammers segmentation options that register template atlases into anatomical space
- generate label and volume tables for atlas segmentations and integrate them with existing outputs and CLI
- document the new segmentations and extend workflow tests

## Testing
- pytest petprep/workflows/pet/tests/test_segmentation.py

------
https://chatgpt.com/codex/tasks/task_e_68f0b25718388330aa093eecc3d76c8f