### PR TITLE
Register atlas segmentations using brain masks

### DIFF
--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -535,6 +535,7 @@ It is released under the [CC0]\
                 segmentation_wf,
                 [
                     ('outputnode.t1w_preproc', 'inputnode.t1w_preproc'),
+                    ('outputnode.t1w_mask', 'inputnode.t1w_mask'),
                     ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
                     ('outputnode.subject_id', 'inputnode.subject_id'),
                 ],

--- a/petprep/workflows/pet/segmentation.py
+++ b/petprep/workflows/pet/segmentation.py
@@ -86,6 +86,28 @@ def _cast_segmentation(in_file: str) -> str:
     return str(out_file)
 
 
+def _mask_from_segmentation(seg_file: str) -> str:
+    """Generate a binary mask from a segmentation image."""
+
+    from pathlib import Path
+
+    import nibabel as nb
+    import numpy as np
+
+    seg_path = Path(seg_file)
+    seg_img = nb.load(seg_path)
+    data = np.asanyarray(seg_img.dataobj) > 0
+
+    out_img = seg_img.__class__(data.astype(np.uint8), seg_img.affine, seg_img.header)
+    out_img.set_data_dtype(np.uint8)
+
+    suffix = ''.join(seg_path.suffixes)
+    stem = seg_path.name[: -len(suffix)] if suffix else seg_path.name
+    out_file = Path.cwd() / f'{stem}_mask.nii.gz'
+    out_img.to_filename(out_file)
+    return str(out_file)
+
+
 SEGMENTATIONS = {
     'gtm': {
         'interface': SegmentGTM,
@@ -352,7 +374,7 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=['t1w_preproc', 'subjects_dir', 'subject_id']),
+        niu.IdentityInterface(fields=['t1w_preproc', 't1w_mask', 'subjects_dir', 'subject_id']),
         name='inputnode',
     )
     outputnode = pe.Node(
@@ -369,6 +391,16 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
     atlas_spec = spec.get('atlas')
 
     if atlas_spec:
+        mask_node = pe.Node(
+            Function(
+                input_names=['seg_file'],
+                output_names=['out_file'],
+                function=_mask_from_segmentation,
+            ),
+            name=f'{seg}_atlas_mask',
+        )
+        mask_node.inputs.seg_file = atlas_spec['dseg']
+
         reg_node = pe.Node(
             Registration(
                 fixed_image=atlas_spec['template'],
@@ -418,9 +450,11 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
         workflow.connect(
             [
                 (inputnode, reg_node, [('t1w_preproc', 'moving_image')]),
+                (inputnode, reg_node, [('t1w_mask', 'moving_image_mask')]),
                 (inputnode, apply_node, [('t1w_preproc', 'reference_image')]),
                 (reg_node, apply_node, [('inverse_composite_transform', 'transforms')]),
                 (apply_node, cast_node, [('output_image', 'in_file')]),
+                (mask_node, reg_node, [('out_file', 'fixed_image_mask')]),
             ]
         )
 

--- a/petprep/workflows/pet/tests/test_segmentation.py
+++ b/petprep/workflows/pet/tests/test_segmentation.py
@@ -74,6 +74,7 @@ def test_atlas_segmentation_nodes():
         wf = init_segmentation_wf('subcortex')
         node_names = {node.name for node in wf._get_all_nodes()}
 
+        assert 'subcortex_atlas_mask' in node_names
         assert 'subcortex_atlas_reg' in node_names
         assert 'subcortex_atlas_to_native' in node_names
         assert 'cast_subcortex_seg' in node_names


### PR DESCRIPTION
## Summary
- generate atlas brain masks from segmentation volumes and use subject brain masks during registration
- pass the anatomical brain mask into atlas-based segmentation workflows
- extend atlas segmentation tests to cover the new mask node

## Testing
- pytest --override-ini addopts='' petprep/workflows/pet/tests/test_segmentation.py


------
https://chatgpt.com/codex/tasks/task_e_68f14698bb0083308bc3b710c20f005f