### PR TITLE
Use brain-masked T1w for atlas segmentation registration

### DIFF
--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -535,6 +535,7 @@ It is released under the [CC0]\
                 segmentation_wf,
                 [
                     ('outputnode.t1w_preproc', 'inputnode.t1w_preproc'),
+                    ('outputnode.t1w_mask', 'inputnode.t1w_mask'),
                     ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
                     ('outputnode.subject_id', 'inputnode.subject_id'),
                 ],

--- a/petprep/workflows/pet/segmentation.py
+++ b/petprep/workflows/pet/segmentation.py
@@ -8,6 +8,7 @@ from nipype.interfaces.freesurfer import MRIConvert
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
+from niworkflows.interfaces.nibabel import ApplyMask
 
 from ... import config
 from ...data import load as load_data
@@ -388,7 +389,9 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=['t1w_preproc', 'subjects_dir', 'subject_id']),
+        niu.IdentityInterface(
+            fields=['t1w_preproc', 't1w_mask', 'subjects_dir', 'subject_id']
+        ),
         name='inputnode',
     )
     outputnode = pe.Node(
@@ -405,6 +408,8 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
     atlas_spec = spec.get('atlas')
 
     if atlas_spec:
+        mask_node = pe.Node(ApplyMask(), name=f'mask_{seg}_t1w')
+
         reg_node = pe.Node(
             Registration(
                 fixed_image=atlas_spec['template'],
@@ -463,7 +468,11 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
 
         workflow.connect(
             [
-                (inputnode, reg_node, [('t1w_preproc', 'moving_image')]),
+                (inputnode, mask_node, [
+                    ('t1w_preproc', 'in_file'),
+                    ('t1w_mask', 'in_mask'),
+                ]),
+                (mask_node, reg_node, [('out_file', 'moving_image')]),
                 (inputnode, apply_node, [('t1w_preproc', 'reference_image')]),
                 (reg_node, apply_node, [('inverse_composite_transform', 'transforms')]),
                 (apply_node, cast_node, [('output_image', 'in_file')]),

--- a/petprep/workflows/pet/tests/test_segmentation.py
+++ b/petprep/workflows/pet/tests/test_segmentation.py
@@ -74,6 +74,7 @@ def test_atlas_segmentation_nodes():
         wf = init_segmentation_wf('subcortex')
         node_names = {node.name for node in wf._get_all_nodes()}
 
+        assert 'mask_subcortex_t1w' in node_names
         assert 'subcortex_atlas_reg' in node_names
         assert 'subcortex_atlas_to_native' in node_names
         assert 'cast_subcortex_seg' in node_names


### PR DESCRIPTION
## Summary
- register atlas-based segmentations against a skull-stripped T1w by masking the anatomical image prior to ANTs registration
- plumb the anatomical brain mask into the segmentation workflow so atlas registrations have access to it
- update the segmentation workflow test to expect the new masking node

## Testing
- pytest petprep/workflows/pet/tests/test_segmentation.py *(fails in this environment because TemplateFlow metadata queries hang; see run log for details)*

------
https://chatgpt.com/codex/tasks/task_e_68f3d572c1f48330acbbfda6650bca02